### PR TITLE
added z-index:-10 and settings multiWords: true, onKeyup

### DIFF
--- a/src/jquery.suggest.js
+++ b/src/jquery.suggest.js
@@ -23,7 +23,8 @@
       suggestionColor       : '#ccc',
       moreIndicatorClass    : 'suggest-more',
       moreIndicatorText     : '&hellip;',
-      multiWords            : false
+      multiWords            : false,
+      onKeyup               : null
     }, options);
 
     return this.each(function() {
@@ -144,7 +145,6 @@
 	      needle = needle.slice(lastWhitespace);
 	  }
 
-
           // accept suggestion with 'enter' or 'tab'
           // if the suggestion hasn't been accepted yet
           if (code == 9 || code == 13) {
@@ -155,6 +155,7 @@
               $(this).val($(this).val().slice(0,lastWhitespace)+suggestions.terms[suggestions.index]);
               // clean the suggestion for the looks
               $suggest.empty();
+	      if(settings.onKeyup) settings.onKeyup();
               return false;
             }
           }
@@ -198,6 +199,7 @@
               $more.show();
             }
           }
+	  if(settings.onKeyup) settings.onKeyup();
         })
 
         // clear suggestion on blur


### PR DESCRIPTION
Hello polarblau,

I made three changes to jquery.suggest.js:

I added z-index: -10 in the JS so that it works even if there is no CSS to set the z-index: +10 for the input. When I first used the plugin I thought it was broken because it did not work without the CSS.

I added a new option multiWords which defaults to false (existing behavior) but when set to true allows autocompletion of the last word of the text. For example if I type "bla bla bla Py" it will autocomplete Py with Py[thon] and leave "bla bla" unchanged.

I added a new option onKeyup which is called onKeyup.
