### PR TITLE
Add Font Kerning CSS gotten from input element

### DIFF
--- a/src/jquery.suggest.js
+++ b/src/jquery.suggest.js
@@ -47,7 +47,8 @@
           'fontWeight'      : $this.css('fontWeight'),
           'letterSpacing'   : $this.css('letterSpacing'),
           'backgroundColor' : $this.css('backgroundColor'),
-          'color'           : settings.suggestionColor
+          'color'           : settings.suggestionColor,
+          'fontKerning'     : $this.css('fontKerning')
         }
       });
 


### PR DESCRIPTION
Some webfonts we used had different kerning in the input file and the suggest box, meaning the sets of text didn't align. This fork fixes it, which will allow users to set font-kerning: none; on the input to allow the webfonts to line up properly.